### PR TITLE
fix(micronaut-gradle): sdk tasks require a gpr.write.key

### DIFF
--- a/.github/workflows/micronaut-gradle.yml
+++ b/.github/workflows/micronaut-gradle.yml
@@ -462,6 +462,7 @@ jobs:
             application.version=${{ needs.setup.outputs.version }}
             gpr.user=${{ secrets.GPR_USER }}
             gpr.key=${{ secrets.GPR_KEY }}
+            gpr.write.key=${{ secrets.GPR_KEY }}
 
   notify:
     name: Notify

--- a/.github/workflows/micronaut-gradle.yml
+++ b/.github/workflows/micronaut-gradle.yml
@@ -450,6 +450,12 @@ jobs:
       - name: Setup asdf-vm
         uses: kronostechnologies/actions/with-asdf-vm@v0.0.18
 
+      - name: Setup PHP  # TODO: Change the project setup to do that. Maybe put it into actions/with-asdf-vm?
+        uses: shivammathur/setup-php@v2
+        if: matrix.generator == 'php'
+        with:
+          php-version: "7.4"
+
       - name: Generate SDK
         uses: kronostechnologies/actions/generate-openapi-sdk@v0.0.18
         with:


### PR DESCRIPTION
Ça pourrait quand même valoir la peine d'utiliser gpr.key dans le plugin. On n'utilise pas toujours la clé dans un contexte d'écriture.