### PR TITLE
fix(micronaut-gradle): completely skip SDKs when no SDKs are enabled

### DIFF
--- a/.github/workflows/micronaut-gradle.yml
+++ b/.github/workflows/micronaut-gradle.yml
@@ -440,6 +440,7 @@ jobs:
     if: |
       !failure() &&
       !cancelled() &&
+      inputs.enable-openapi-sdk != '' &&
       (! (contains(inputs.checks, 'unit_tests') && contains(inputs.checks, 'e2e_tests')) || success('test_coverage_verification')) &&
       (!contains(inputs.checks, 'static_analysis') || success('static_analysis'))
 


### PR DESCRIPTION
Otherwise GH flags empty matrix inputs as a build failure.