### PR TITLE
Bump docker-build-and-publish to get timestamp docker tag

### DIFF
--- a/.github/workflows/micronaut-gradle.yml
+++ b/.github/workflows/micronaut-gradle.yml
@@ -453,7 +453,7 @@ jobs:
 
       - name: Build and push
         id: build-and-push
-        uses: equisoft-actions/docker-build-and-push@v1.1.0
+        uses: equisoft-actions/docker-build-and-push@v1.1.1
         with:
           registry: ${{ secrets.ECR_REGISTRY }}
           aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/webapp-frontend.yml
+++ b/.github/workflows/webapp-frontend.yml
@@ -323,7 +323,7 @@ jobs:
 
       - name: Build and push
         id: build-and-push
-        uses: equisoft-actions/docker-build-and-push@v1.1.0
+        uses: equisoft-actions/docker-build-and-push@v1.1.1
         with:
           registry: ${{ secrets.ECR_REGISTRY }}
           aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
C'est mieux de fonctionner, parce que c'est long monter ça jusque dans un projet