### PR TITLE
fix(micronaut): increase docker builder max-memory to 7Gi

### DIFF
--- a/.github/workflows/micronaut-gradle.yml
+++ b/.github/workflows/micronaut-gradle.yml
@@ -484,7 +484,7 @@ jobs:
           platforms: ${{ steps.platforms.outputs.platforms }}
           push: ${{ inputs.publish-image }}
           is-release: ${{ needs.setup.outputs.is-release }}
-          max-memory: 6Gi
+          max-memory: 7Gi
           use-emulation: ${{ needs.setup.outputs.use-emulation }}
           version: ${{ needs.setup.outputs.version }}
           working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Le build de financial-api passe pas sinon :/